### PR TITLE
Fix typo in doc attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! assert_eq!(&output.unwrap(), "Finally! Some gtmpl for Rust");
 //! ```
 mod exec;
-#[doc(inlne)]
+#[doc(inline)]
 pub mod funcs;
 mod lexer;
 mod node;


### PR DESCRIPTION
The mistyped attribute parameter for doc(inline) fails the build with the nightly compiler.