### PR TITLE
printf: handle Array and Map

### DIFF
--- a/src/print_verb.rs
+++ b/src/print_verb.rs
@@ -75,6 +75,28 @@ pub fn print(p: &FormatParams, typ: char, val: &Value) -> Result<String, PrintEr
             }
             _ => return Err(PrintError::UnableToFormat(val.clone(), typ)),
         }),
+        Value::Array(ref a) => Ok(match typ {
+            'v' => {
+                let values: Vec<String> = a.iter().map(|v| printf_generic(p, v)).collect();
+                let res = format!("[{}]", values.join(" "));
+                printf_generic(p, res)
+            }
+            _ => return Err(PrintError::UnableToFormat(val.clone(), typ)),
+        }),
+        Value::Map(ref m) => Ok(match typ {
+            'v' => {
+                let values: Vec<String> = m
+                    .iter()
+                    .map(|(k, v)| {
+                        let v_str = printf_generic(p, v);
+                        format!("{}:{}", k, v_str)
+                    })
+                    .collect();
+                let res = format!("map[{}]", values.join(" "));
+                printf_generic(p, res)
+            }
+            _ => return Err(PrintError::UnableToFormat(val.clone(), typ)),
+        }),
         _ => Err(PrintError::UnableToFormat(val.clone(), typ)),
     }
 }

--- a/src/printf.rs
+++ b/src/printf.rs
@@ -224,6 +224,8 @@ pub fn params_to_chars(params: &FormatParams) -> (char, char, char, char, char) 
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashMap;
+
     use super::*;
 
     #[test]
@@ -305,6 +307,41 @@ mod test {
         assert!(s.is_ok());
         let s = s.unwrap();
         assert_eq!(s, r"+101");
+    }
+
+    #[test]
+    fn test_sprintf_array() {
+        let values: Vec<Value> = vec!["hello".into(), "world".into()];
+        let s = sprintf("foo %v", &[Value::Array(values)]);
+        assert!(s.is_ok());
+        let s = s.unwrap();
+        assert_eq!(s, r"foo [hello world]");
+
+        let values: Vec<Value> = vec![42.into(), 100.into()];
+        let s = sprintf("foo %v", &[Value::Array(values)]);
+        assert!(s.is_ok());
+        let s = s.unwrap();
+        assert_eq!(s, r"foo [42 100]");
+    }
+
+    #[test]
+    fn test_sprintf_map() {
+        let mut values: HashMap<String, Value> = HashMap::new();
+        values.insert("hello".into(), "world".into());
+        values.insert("number".into(), 42.into());
+        let s = sprintf("foo %v", &[Value::Map(values)]);
+        assert!(s.is_ok());
+        let s = s.unwrap();
+        // The print order is unpredictable, we can't write
+        // a straight comparison
+        assert!(s == "foo map[number:42 hello:world]" || s == "foo map[hello:world number:42]");
+
+        let mut values: HashMap<String, Value> = HashMap::new();
+        values.insert("float".into(), 4.2.into());
+        let s = sprintf("%v", &[Value::Map(values)]);
+        assert!(s.is_ok());
+        let s = s.unwrap();
+        assert_eq!(s, r"map[float:4.2]");
     }
 
     #[test]


### PR DESCRIPTION
Handle printing of `%v` with Array and Map objects.

Obviously this won't cover 100% of the cases, but it's better than nothing